### PR TITLE
[Build-trigger-38] Removing unsecure property quarkus.tls.trust-all=true

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,9 +53,6 @@ quarkus.http.auth.permission.authenticated.policy=authenticated
 quarkus.oidc.token-state-manager.split-tokens=true
 %prod.quarkus.oidc.authentication.force-redirect-https-scheme=true
 
-# REST client
-quarkus.tls.trust-all=true
-
 # test
 %test.quarkus.qpid-jms.url=not-required
 %test.build-trigger.topic=not-required


### PR DESCRIPTION
resolves https://github.com/jboss-set/build-trigger/issues/38

In issue: https://github.com/jboss-set/build-trigger/issues/54 this property was causing a warning "[io.qua.mai.run.Mailers] (executor-thread-1) The default TLS configuration is set to trust all certificates. This is a security risk. Please use a named TLS configuration for the mailer <default> to avoid this warning.".
After playing around with it it looks like we do not need this property. I can't see anything that is not working without it. Am I overlooking something? 